### PR TITLE
Add docs checks & linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: avto-dev/markdown-lint@v1
+

--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -2,10 +2,10 @@
 
 **Version:** `v1`  |  **Base URL:** `http(s)://<host>:8000` (native) / `http://localhost` (Docker) 
 
-This document specifies all HTTP & WebSocket interfaces exposed by the Lie‑Ability game server.  All routes are mounted under `/api/v1` except the WebSocket, which is `/ws`.
+This document specifies all HTTP and WebSocket interfaces for the Lie‑Ability game server. The server mounts all routes under `/api/v1` and exposes the WebSocket at `/ws`.
 
 > **Tech stack**: FastAPI + Uvicorn + SQLAlchemy + Redis Pub/Sub.
-> JSON payloads use **camelCase** keys.  All examples are truncated for brevity.
+> JSON payloads use **camelCase** keys. We truncate examples for brevity.
 
 ---
 
@@ -75,7 +75,7 @@ wss://<host>/ws/lobbies/{code}?token=<jwt>
 ```
 
 * Requires a valid JWT; server disconnects after 3 × failed pings.
-* Binary messages are ignored.
+* The server ignores binary messages.
 
 ### 3.2 Envelope Format
 
@@ -182,7 +182,7 @@ ws.onmessage = (e) => console.log(JSON.parse(e.data));
 
 ---
 
-## 8 · TODO / Future Endpoints
+## 8 · Future Endpoints
 
 * `GET /stats/global` – fetch global leaderboard.
 * `POST /games/{id}/chat` – in‑game chatter.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -2,7 +2,7 @@
 
 *Last updated: 2025‑06‑02*
 
-This document describes the public‑facing HTTP and WebSocket APIs exposed by the **Lie‑Ability** game server.  All traffic is JSON‑encoded (UTF‑8) and served over HTTPS or `ws[s]://` in production; plain HTTP/WebSocket is allowed in local development.
+This document describes the public-facing HTTP and WebSocket APIs for the **Lie‑Ability** game server. The server encodes all traffic as JSON (UTF‑8). Production uses HTTPS or `ws[s]://`, while local development permits plain HTTP and WebSocket.
 
 > **Scope**
 > ‑ High‑level resource map for REST endpoints
@@ -114,7 +114,7 @@ interface Scoreboard {
 }
 ```
 
-Full JSON Schema files live under `backend/schemas/` and are bundled into the auto‑generated **ReDoc** docs (`make redoc`).
+The auto-generated **ReDoc** docs bundle the full JSON Schema files from `backend/schemas/` (`make redoc`).
 
 ---
 
@@ -122,7 +122,7 @@ Full JSON Schema files live under `backend/schemas/` and are bundled into the au
 
 * **REST** – 60 req/min per IP (429 on exceed).
 * **WebSocket** – heartbeat ping every 15 s, disconnect after 40 s of silence.
-* Lie submission / voting windows enforced server‑side; late packets are NACKed with `error { code:"timeout" }`.
+* The server enforces lie submission and voting windows; it NACKs late packets with `error { code:"timeout" }`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Lie‑Ability is a real‑time, bluff‑based trivia game designed to run on a single host machine but be played across many personal devices.  The system is composed of a **Python backend** that maintains game state and a **TypeScript frontend** rendered twice: once as the **Shared Display** (projector/TV) and once per **Player Device** (phones/tablets).  All views communicate with the backend through WebSockets for sub‑second bidirectional updates.
+Lie‑Ability is a real‑time, bluff‑based trivia game that runs on a single host machine and lets players connect from personal devices. The system combines a **Python backend** that maintains game state with a **TypeScript frontend** shown on the **Shared Display** (projector/TV) and on each **Player Device** (phones/tablets). All views communicate with the backend through WebSockets for sub‑second updates.
 
 > **Goals**
 >
@@ -63,7 +63,7 @@ stateDiagram-v2
 * **Reveal** – truth exposed, points assigned.
 * **Scores** – running tally & winner highlight; repeat or end.
 
-All state changes are emitted over WebSocket events; the client views render purely from the last known state.
+The server emits all state changes over WebSocket events, and the client views render solely from the last known state.
 
 ---
 
@@ -151,7 +151,7 @@ lie-ability/
 | `APP_ENV`      | `dev`                      | `dev` = hot‑reload; `prod` = optimized |
 | `DATABASE_URL` | `sqlite:///lieability.db`  | SQLAlchemy DSN                         |
 | `REDIS_URL`    | `redis://localhost:6379/0` | Pub/Sub broker                         |
-| `SECRET_KEY`   | *generate*                 | JWT & session signing                  |
+| `SECRET_KEY`   | `please_change_me`                 | JWT & session signing                  |
 
 Place overrides in `.env` (read by both Docker & native launcher).
 

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -6,7 +6,7 @@
 
 ## 1 · Ground Rules
 
-1. **Be kind & constructive.**  We follow the [Contributor Covenant](../CODE_OF_CONDUCT.md).
+1. **Be kind & constructive.**  We follow the [Contributor Covenant](https://contributor-covenant.org/version/2/1/code_of_conduct/).
 2. **No spoilers.**  Don’t submit copyrighted trivia prompts.
 3. **Respect the license (CC BY‑NC 4.0)** — your PR means you agree to release your contribution under the same terms.
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -156,7 +156,7 @@ SQLite in dev; PostgreSQL in Docker/prod.
 
 ## 10 · VS Code Devcontainer *(optional)*
 
-A `.devcontainer` folder is included.
+The repository includes a `.devcontainer` folder.
 
 ```bash
 # inside VS Code

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Lie‑Ability is a light‑hearted bluff‑and‑guess trivia game for **2 – 8 players**.  Each round delivers an obscure prompt; players must invent a believable lie while spotting the truth themselves. Points are awarded for:
+Lie‑Ability is a light‑hearted bluff‑and‑guess trivia game for **2 – 8 players**.  Each round delivers an obscure prompt; players must invent a believable lie while spotting the truth themselves. You earn points for:
 
 * **Truth Sleuth** – choosing the real answer.
 * **Master Liar** – fooling friends into picking your lie.
@@ -23,11 +23,10 @@ A standard game lasts **3 rounds** (≈ 15 min), but the host can restart with t
 ---
 
 ## Joining a Game
-
 1. Host opens the **Shared Display** (TV/projector) – it shows a QR code containing the lobby URL (LAN‑only or public, configurable).
 2. Players scan or type the URL on a personal device.
-3. Choose a nickname & avatar (emoji carousel + color wheel). Duplicate names are blocked.
-4. When **≥ 2 players** have joined, the **Start Game** button is enabled for the host.
+3. Choose a nickname & avatar (emoji carousel + color wheel). The server blocks duplicate names.
+4. Once at least two players join, the host can press the **Start Game** button.
 
 > **Zero‑install onboarding** – everything runs in a mobile browser.
 
@@ -68,7 +67,7 @@ sequenceDiagram
 
 Round multipliers: × 2 in round 2, × 3 in the final round.
 
-*Tie‑breakers*: If scores tie, multiple winners are crowned – bragging rights shared!
+*Tie‑breakers*: If scores tie, the game crowns multiple winners so everyone shares bragging rights!
 
 ---
 
@@ -88,7 +87,7 @@ category,prompt,answer
 "TRIVIA TIME","Mickey Mouse's middle name is _____.","Theodore"
 ```
 
-Each row becomes one prompt; duplicate categories are grouped in‑game.
+The game groups duplicate categories, with each row becoming one prompt.
 
 ---
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,88 @@
+import re
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+
+ENV_PATTERN_ASSIGN = re.compile(r"^([A-Z]+_[A-Z0-9_]+)=(\S+)")
+ENV_PATTERN_TABLE = re.compile(r"\|\s*`?([A-Z]+_[A-Z0-9_]+)`?\s*\|\s*`?([^`|]+)`?\s*\|")
+LINK_PATTERN = re.compile(r"\[([^\]]+)\]\((?!http)([^)#]+)(#[^)]+)?\)")
+
+
+def slugify(text: str) -> str:
+    slug = text.lower()
+    slug = re.sub(r"[^a-z0-9 -]", "", slug)
+    slug = slug.replace(" ", "-")
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug
+
+
+def extract_headings(text: str):
+    headings = []
+    in_code = False
+    for line in text.splitlines():
+        if line.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        m = re.match(r"^(#+)\s+(.*)", line)
+        if m:
+            headings.append(m.group(2).strip())
+    return headings
+
+
+def extract_envs(text: str):
+    envs = []
+    for line in text.splitlines():
+        m1 = ENV_PATTERN_ASSIGN.match(line.strip())
+        if m1:
+            envs.append((m1.group(1), m1.group(2)))
+        m2 = ENV_PATTERN_TABLE.search(line)
+        if m2:
+            envs.append((m2.group(1), m2.group(2)))
+    return envs
+
+
+def collect_anchors(path: Path):
+    anchors = set()
+    text = path.read_text()
+    for heading in extract_headings(text):
+        anchors.add(slugify(heading))
+    return anchors
+
+
+def iter_docs():
+    return sorted(DOCS_DIR.rglob("*.md"))
+
+
+def test_no_duplicate_headings_and_no_todo():
+    for md in iter_docs():
+        text = md.read_text()
+        assert "TODO" not in text, f"TODO found in {md}"
+        headings = extract_headings(text)
+        duplicates = {h for h in headings if headings.count(h) > 1}
+        assert not duplicates, f"Duplicate headings in {md}: {duplicates}"
+
+
+def test_env_defaults_consistent():
+    defaults = {}
+    for md in iter_docs():
+        for env, val in extract_envs(md.read_text()):
+            if env in defaults and defaults[env] != val:
+                raise AssertionError(f"Conflicting default for {env}: {defaults[env]} vs {val} in {md}")
+            defaults.setdefault(env, val)
+
+
+def test_internal_links_resolve():
+    anchor_cache = {}
+    for md in iter_docs():
+        text = md.read_text()
+        for label, target, anchor in LINK_PATTERN.findall(text):
+            target_path = (md.parent / target).resolve()
+            assert target_path.exists(), f"Broken link {target} in {md}"
+            if anchor:
+                slug = anchor.lstrip("#")
+                if target_path not in anchor_cache:
+                    anchor_cache[target_path] = collect_anchors(target_path)
+                assert slug in anchor_cache[target_path], f"Missing anchor {anchor} in {target_path}"
+


### PR DESCRIPTION
## Summary
- reword passive voice and fix broken link in docs
- unify SECRET_KEY default
- remove TODO heading
- add markdown lint workflow
- enforce docs quality via pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e4215c048833090454c9167b4e851