### PR TITLE
Add offline dev guide

### DIFF
--- a/docs/dev/offline.md
+++ b/docs/dev/offline.md
@@ -1,0 +1,25 @@
+# Offline Development & CI
+
+Running the project without Internet requires pre-downloading all dependencies.
+
+## 1 \xc2\xb7 Prep Script
+
+Execute `scripts/prep_env.sh` **while online**. It downloads Python wheels and npm packages to `.cache/` and builds `.venv/`. The frontend production bundle is also compiled.
+
+## 2 \xc2\xb7 Caching
+
+Commit the `.cache/pip/` and `.cache/npm/` directories or store them as CI artifacts. Optionally commit `.venv/` and `frontend/node_modules/` if your CI can't restore caches.
+
+## 3 \xc2\xb7 Installing
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install --no-index --find-links=.cache/pip -r backend/requirements.txt
+cd frontend
+npm ci --prefer-offline --no-audit --progress=false
+```
+
+## 4 \xc2\xb7 Workflow Tips
+
+Run all build and test steps after the dependencies are installed from local sources. Ensure `prep_env.sh` runs only when Internet access is available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Welcome to the **Lie‑Ability** documentation hub — your one‑stop guide to 
 | 🔄 **WebSocket API**  | [docs/api/websocket.md](./api/websocket.md)       |
 | 🛠️ **Dev Setup**     | [docs/dev/setup.md](./dev/setup.md)               |
 | 🐳 **Docker Guide**   | [docs/dev/docker.md](./dev/docker.md)             |
+| 📴 **Offline Setup**  | [docs/dev/offline.md](./dev/offline.md)           |
 | 🤝 **Contributing**   | [docs/dev/contributing.md](./dev/contributing.md) |
 
 ---


### PR DESCRIPTION
## Summary
- document how to prep dependencies for offline CI
- link new guide from index

## Testing
- `pytest tests/test_docs.py::test_no_duplicate_headings_and_no_todo -q`
- `pytest tests/test_docs.py::test_env_defaults_consistent -q`
- `pytest tests/test_docs.py::test_internal_links_resolve -q`
- ❌ `pytest -q` *(fails: /workspace/lie-ability/.venv/bin/pytest: No such file or directory)*
- ❌ `npm test --workspaces` *(fails: No workspaces found)*


------
https://chatgpt.com/codex/tasks/task_e_683e4bfeb9f08330885f933ba3e8977d