### PR TITLE
Implement game state machine

### DIFF
--- a/backend/game/engine.py
+++ b/backend/game/engine.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Dict, List
+
+from .models import Lobby, Phase
+from .state import (
+    AUTO_LIE_PENALTY,
+    FOOL_POINTS,
+    GameState,
+    TRUTH_POINTS,
+    compute_multiplier,
+    get_prompt,
+    make_choice,
+)
+
+# Timers (seconds)
+PROMPT_DELAY = int(os.getenv("PROMPT_DELAY", 1))
+LIE_TIMER = int(os.getenv("LIE_TIMER", 30))
+VOTE_TIMER = int(os.getenv("VOTE_TIMER", 20))
+SCOREBOARD_TIMER = int(os.getenv("SCOREBOARD_TIMER", 8))
+
+_games: Dict[str, GameState] = {}
+_broadcast_handlers: Dict[str, List] = {}
+
+
+def register_broadcaster(code: str, handler) -> None:
+    """Subscribe to broadcast events for a lobby."""
+    _broadcast_handlers.setdefault(code, []).append(handler)
+
+
+def unregister_broadcaster(code: str, handler) -> None:
+    """Remove broadcast subscriber."""
+    if code in _broadcast_handlers:
+        _broadcast_handlers[code].remove(handler)
+        if not _broadcast_handlers[code]:
+            del _broadcast_handlers[code]
+
+
+async def broadcast(code: str, msg: dict) -> None:
+    """Send JSON message to all subscribers."""
+    handlers = list(_broadcast_handlers.get(code, []))
+    for handler in handlers:
+        await handler(msg)
+
+
+# ------------------ Game actions ------------------
+
+
+def start_game(lobby: Lobby) -> GameState:
+    """Create a game instance for the given lobby and launch the loop."""
+    game = GameState(lobby=lobby, round_count=lobby.round_count)
+    _games[lobby.code] = game
+    asyncio.create_task(_run_game(game))
+    return game
+
+
+def get_game(code: str) -> GameState | None:
+    """Return the active GameState for a lobby, if any."""
+    return _games.get(code)
+
+
+async def submit_lie(code: str, player_id: str, text: str) -> None:
+    """Record a lie from a player during the submission phase."""
+    game = _games.get(code)
+    if not game or game.phase != "LIE_SUBMISSION":
+        return
+    game.lies[player_id] = text.strip() or "Auto Lie"
+
+
+async def submit_vote(code: str, player_id: str, choice_id: str) -> None:
+    """Record a vote from a player during the voting phase."""
+    game = _games.get(code)
+    if not game or game.phase != "VOTING":
+        return
+    if player_id in game.votes:
+        return
+    choice = next((c for c in game.choices if c.id == choice_id), None)
+    if not choice or choice.author_id == player_id:
+        return
+    game.votes[player_id] = choice_id
+
+
+# ------------------ Game loop ------------------
+async def _run_game(game: GameState) -> None:
+    """Main asynchronous loop progressing through all rounds."""
+    code = game.lobby.code
+    for rnd in range(1, game.round_count + 1):
+        game.round_number = rnd
+        prompt = get_prompt()
+        game.prompt_id = prompt["id"]
+        game.prompt_category = prompt["category"]
+        game.prompt_text = prompt["text"]
+        await broadcast(
+            code,
+            {
+                "type": "prompt",
+                "payload": {
+                    "id": game.prompt_id,
+                    "category": game.prompt_category,
+                    "text": game.prompt_text,
+                },
+                "ts": int(time.time() * 1000),
+            },
+        )
+        await _phase(game, "LIE_SUBMISSION", LIE_TIMER)
+        # Build choices
+        game.choices = [make_choice(prompt["answer"], None)]
+        for pid, text in game.lies.items():
+            game.choices.append(make_choice(text, pid))
+        await broadcast(
+            code,
+            {
+                "type": "choices",
+                "payload": {"list": [c.model_dump() for c in game.choices]},
+                "ts": int(time.time() * 1000),
+            },
+        )
+        await _phase(game, "VOTING", VOTE_TIMER)
+        await _reveal(game, prompt)
+        await _scoreboard(game)
+    await _game_over(game)
+
+
+async def _phase(game: GameState, phase: Phase, duration: int) -> None:
+    """Broadcast a phase change and sleep for the given duration."""
+    game.phase = phase
+    game.deadline = time.time() + duration
+    await broadcast(
+        game.lobby.code,
+        {
+            "type": "phase_change",
+            "payload": {"phase": phase, "deadline": int(game.deadline * 1000)},
+            "ts": int(time.time() * 1000),
+        },
+    )
+    if duration:
+        await asyncio.sleep(duration)
+
+
+async def _reveal(game: GameState, prompt: dict) -> None:
+    """Calculate scores and broadcast reveal results."""
+    code = game.lobby.code
+    game.phase = "REVEAL"
+    await broadcast(
+        code,
+        {
+            "type": "phase_change",
+            "payload": {"phase": "REVEAL", "deadline": int(time.time() * 1000)},
+            "ts": int(time.time() * 1000),
+        },
+    )
+    truth_choice = next(c for c in game.choices if c.author_id is None)
+    fooled = []
+    delta: Dict[str, int] = {pid: 0 for pid in game.scores}
+    multiplier = compute_multiplier(game.round_number)
+    for voter, cid in game.votes.items():
+        choice = next(c for c in game.choices if c.id == cid)
+        if choice.author_id is None:
+            delta[voter] += TRUTH_POINTS * multiplier
+        elif choice.author_id == "AUTO":
+            delta[voter] -= AUTO_LIE_PENALTY * multiplier
+        else:
+            fooled.append({"victimId": voter, "liarId": choice.author_id})
+            delta[choice.author_id] += FOOL_POINTS * multiplier
+    for pid, pts in delta.items():
+        game.scores[pid] += pts
+    await broadcast(
+        code,
+        {
+            "type": "reveal",
+            "payload": {
+                "truthId": truth_choice.id,
+                "fooled": fooled,
+                "scoresDelta": delta,
+            },
+            "ts": int(time.time() * 1000),
+        },
+    )
+    await asyncio.sleep(max(1, len(game.choices) * 2))
+
+
+async def _scoreboard(game: GameState) -> None:
+    """Broadcast cumulative scores for all players."""
+    await _phase(game, "SCOREBOARD", SCOREBOARD_TIMER)
+    scores = [
+        {"playerId": pid, "total": total}
+        for pid, total in sorted(game.scores.items(), key=lambda p: -p[1])
+    ]
+    await broadcast(
+        game.lobby.code,
+        {
+            "type": "scoreboard",
+            "payload": {"scores": scores},
+            "ts": int(time.time() * 1000),
+        },
+    )
+    if SCOREBOARD_TIMER:
+        await asyncio.sleep(SCOREBOARD_TIMER)
+
+
+async def _game_over(game: GameState) -> None:
+    """Finalize the game and broadcast winners."""
+    game.phase = "GAME_OVER"
+    await broadcast(
+        game.lobby.code,
+        {
+            "type": "phase_change",
+            "payload": {"phase": "GAME_OVER", "deadline": int(time.time() * 1000)},
+            "ts": int(time.time() * 1000),
+        },
+    )
+    scores = [
+        {"playerId": pid, "total": total}
+        for pid, total in sorted(game.scores.items(), key=lambda p: -p[1])
+    ]
+    await broadcast(
+        game.lobby.code,
+        {
+            "type": "game_over",
+            "payload": {"final": scores},
+            "ts": int(time.time() * 1000),
+        },
+    )
+    _games.pop(game.lobby.code, None)

--- a/backend/game/models.py
+++ b/backend/game/models.py
@@ -4,6 +4,24 @@ from pydantic import BaseModel
 from typing import Literal
 
 
+Phase = Literal[
+    "LOBBY",
+    "LIE_SUBMISSION",
+    "VOTING",
+    "REVEAL",
+    "SCOREBOARD",
+    "GAME_OVER",
+]
+
+
+class Choice(BaseModel):
+    """Selectable option shown during voting."""
+
+    id: str
+    text: str
+    author_id: str | None
+
+
 class Player(BaseModel):
     """Player state."""
 

--- a/backend/game/state.py
+++ b/backend/game/state.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import random
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from .models import Choice, Lobby, Phase
+
+
+@dataclass
+class GameState:
+    """Mutable game state for one lobby."""
+
+    lobby: Lobby
+    round_count: int
+    round_number: int = 0
+    phase: Phase = "LOBBY"
+    prompt_id: Optional[str] = None
+    prompt_category: Optional[str] = None
+    prompt_text: Optional[str] = None
+    choices: List[Choice] = field(default_factory=list)
+    lies: Dict[str, str] = field(default_factory=dict)
+    votes: Dict[str, str] = field(default_factory=dict)
+    scores: Dict[str, int] = field(default_factory=dict)
+    deadline: float = 0.0
+
+    def __post_init__(self) -> None:
+        for p in self.lobby.players:
+            self.scores[p.id] = 0
+
+
+# ------------------ Prompt source ------------------
+PROMPTS = [
+    {
+        "id": "p1",
+        "category": "TRIVIA TIME",
+        "text": "Mickey Mouse's middle name is _____.",
+        "answer": "Theodore",
+    },
+    {
+        "id": "p2",
+        "category": "CELEBRITY TWEET",
+        "text": "@realDonaldTrump: Who wouldn't take _____'s picture and make lots of money if she does the nude sunbathing thing?",
+        "answer": "Kate Middleton",
+    },
+]
+
+
+def get_prompt() -> dict:
+    """Return a random prompt from the built-in list."""
+    return random.choice(PROMPTS)
+
+
+# ------------------ Scoring ------------------
+TRUTH_POINTS = 500
+FOOL_POINTS = 250
+AUTO_LIE_PENALTY = 500
+
+
+def compute_multiplier(round_number: int) -> int:
+    return max(1, round_number)
+
+
+# ------------------ Utility ------------------
+
+
+def make_choice(text: str, author: Optional[str]) -> Choice:
+    return Choice(id=str(uuid.uuid4()), text=text, author_id=author)

--- a/backend/lobbies.py
+++ b/backend/lobbies.py
@@ -7,6 +7,7 @@ from typing import Dict
 
 from .auth import encode
 from .game.models import Lobby, Player
+from .game import engine
 
 _lobbies: Dict[str, Lobby] = {}
 
@@ -43,3 +44,4 @@ def add_player(code: str, nickname: str, avatar: str) -> tuple[Player, str]:
 def start_game(code: str) -> None:
     lobby = _lobbies[code]
     lobby.state = "IN_GAME"
+    engine.start_game(lobby)

--- a/backend/tests/test_game_engine.py
+++ b/backend/tests/test_game_engine.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from backend import lobbies
+from backend.game import engine
+
+
+@pytest.mark.asyncio
+async def test_game_reaches_game_over(monkeypatch) -> None:
+    monkeypatch.setattr(engine, "LIE_TIMER", 0)
+    monkeypatch.setattr(engine, "VOTE_TIMER", 0)
+    monkeypatch.setattr(engine, "SCOREBOARD_TIMER", 0)
+    lobby, _ = lobbies.create_lobby(1)
+    lobbies.add_player(lobby.code, "A", "🐍")
+    lobbies.add_player(lobby.code, "B", "🐍")
+    events: list[dict] = []
+
+    async def handler(msg: dict) -> None:
+        events.append(msg)
+
+    engine.register_broadcaster(lobby.code, handler)
+    engine.start_game(lobby)
+    await asyncio.sleep(0.05)
+    assert any(e["type"] == "game_over" for e in events)


### PR DESCRIPTION
## Summary
- model game phases and choices
- implement state machine with timers and WebSocket events
- connect WebSocket handlers to game engine
- add minimal async test for game loop

## Testing
- `ruff check backend/game backend/main.py backend/lobbies.py backend/tests/test_game_engine.py`
- `black --check backend/game/state.py backend/game/engine.py backend/main.py backend/lobbies.py backend/tests/test_game_engine.py`
- `mypy backend/`
- `pytest -q` *(fails: ModuleNotFoundError due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_683e520933f0833092bcb05ca0d40bc0