### PR TITLE
Update startup script to open frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ All you need is:
 
 This will:
 
-* Launch the server
-* Open the shared display in a new browser window
+* Launch the backend and frontend dev servers
+* Try to open the shared display automatically (see output)
+
+If the browser does not open, visit:
+
+* Player view: <http://localhost:5173>
+* Shared display: <http://localhost:5173/shared>
 
 > 🧪 Not tested on Windows yet — PRs welcome!
 

--- a/start.sh
+++ b/start.sh
@@ -17,6 +17,17 @@ if [ "$USE_NATIVE" = true ]; then
   BACK_PID=$!
   (cd frontend && npm run dev) &
   FRONT_PID=$!
+
+  # Attempt to open the shared display automatically
+  if command -v xdg-open >/dev/null; then
+    xdg-open http://localhost:5173/shared >/dev/null 2>&1 &
+  elif command -v open >/dev/null; then
+    open http://localhost:5173/shared >/dev/null 2>&1 &
+  fi
+
+  echo "Player view: http://localhost:5173"
+  echo "Shared display: http://localhost:5173/shared"
+
   trap 'kill $BACK_PID $FRONT_PID' INT TERM
   wait
 else


### PR DESCRIPTION
## Summary
- launch the dev server with browser auto-open hints
- clarify Quickstart instructions about the local URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `mypy backend/`
- `ruff check .`
- `black --check .`
- `npm test --workspaces` *(fails: package.json missing)*
- `npm run lint && npm run format:check` *(fails: package.json missing)*
- `pytest tests/e2e/` *(fails: directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_683efee1dc14833086cecbc449923239