### PR TITLE
fix: correct dev proxy and host URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This will:
 If the browser does not open, visit:
 
 * Player view: <http://localhost:5173>
-* Shared display: <http://localhost:5173/shared>
+* Shared display: <http://localhost:5173/host>
 
 > 🧪 Not tested on Windows yet — PRs welcome!
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ cd frontend && npm ci && npm run build
 uvicorn backend.main:app --reload  # http://localhost:8000
 ```
 
-Then open `http://localhost:5173` (player) and `http://localhost:5173/shared` (shared display).
+Then open `http://localhost:5173` (player) and `http://localhost:5173/host` (shared display).
 
 ### 2. Docker Compose
 

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -42,7 +42,7 @@ $ cd frontend && npm run dev &
 
 # 3 • Open your browser
 # Player view: http://localhost:5173
-# Shared display: http://localhost:5173/shared
+# Shared display: http://localhost:5173/host
 ```
 
 Running `./start.sh -n` performs these steps for you automatically.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Lie‑Ability is an open‑source party trivia game inspired by *Fibbage*. Up to
    ```bash
    docker compose up --build
    ```
-3. Open [http://localhost](http://localhost) (player view) and [http://localhost/shared](http://localhost/shared) (shared display).
+3. Open [http://localhost](http://localhost) (player view) and [http://localhost/host](http://localhost/host) (shared display).
 4. Scan the QR code, choose a nickname, and start lying!
 
 For full environment details see **[Dev Setup](./dev/setup.md)**.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/': 'http://localhost:8000'
+      '/api': 'http://localhost:8000',
+      '/healthz': 'http://localhost:8000',
+      '/ws': { target: 'ws://localhost:8000', ws: true }
     }
   }
 });

--- a/start.sh
+++ b/start.sh
@@ -18,15 +18,15 @@ if [ "$USE_NATIVE" = true ]; then
   (cd frontend && npm run dev) &
   FRONT_PID=$!
 
-  # Attempt to open the shared display automatically
+  # Attempt to open the host view automatically
   if command -v xdg-open >/dev/null; then
-    xdg-open http://localhost:5173/shared >/dev/null 2>&1 &
+    xdg-open http://localhost:5173/host >/dev/null 2>&1 &
   elif command -v open >/dev/null; then
-    open http://localhost:5173/shared >/dev/null 2>&1 &
+    open http://localhost:5173/host >/dev/null 2>&1 &
   fi
 
   echo "Player view: http://localhost:5173"
-  echo "Shared display: http://localhost:5173/shared"
+  echo "Host view: http://localhost:5173/host"
 
   trap 'kill $BACK_PID $FRONT_PID' INT TERM
   wait


### PR DESCRIPTION
## Summary
- fix dev proxy rules in `vite.config.ts`
- update the auto-opened URL in `start.sh`
- replace `/shared` with `/host` in docs and README

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError)*
- `mypy backend/`
- `npm test --workspaces` *(fails: no package.json)*
- `npm run lint` *(fails: ESLint config error)*
- `npm run format:check` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f1735ad88833089ee5ea4c9151f8d